### PR TITLE
Update README to use correct token key

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Response:
     "status": "OK",
     "statusCode": 200,
     "data": {
-        "accessToken": "<JWT>",
+        "token": "<JWT>",
         "userId": "<User ID>"
     },
     "meta": {}


### PR DESCRIPTION
The API returns `token`, not `accessToken`.